### PR TITLE
No toolhead sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ gear_stepper: manual_stepper gear_stepper                  # full name is requir
 selector_stepper: manual_stepper selector_stepper          # full name is required
 servo: servo ercf_servo                                    # full name is required
 toolhead_sensor: filament_switch_sensor toolhead_sensor    # full name is required
-encoder_pin: ebb_ercf_02:PB3                               # The pin must be shared via [duplicate_pin_override]
+encoder_pin: ercf:gpio15                                   # The pin must be shared via [duplicate_pin_override]
 
 servo_up_angle: 30                                         # The angle when the servo arm is in UP position. See the ERCF manual for more information.
 servo_down_angle: 115                                      # The angle when the servo arm is in DOWN position. See the ERCF manual for more information.
@@ -83,6 +83,7 @@ selector_filament_engagement_retry: 2                      # The maximum retry w
 auto_home_selector: True                                   # Automatically home the selector if not homed previously when a selector move is requested.
 tip_forming_gcode_before_calibration: None                 # The tip forming gcode to run before running the calibration routine (_ERCF_CALIBRATE_COMPONENT_LENGTH).
 slip_detection_ratio_threshold: 3                          # If the actual move distance is less than [1/threshold * requested_distance] then the code will consider it slip
+servo_down_turn_off: False                                 # Select whether to turn off the servo motor while the arm is in place
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ auto_home_selector: True                                   # Automatically home 
 tip_forming_gcode_before_calibration: None                 # The tip forming gcode to run before running the calibration routine (_ERCF_CALIBRATE_COMPONENT_LENGTH).
 slip_detection_ratio_threshold: 3                          # If the actual move distance is less than [1/threshold * requested_distance] then the code will consider it slip
 servo_down_turn_off: False                                 # Select whether to turn off the servo motor while the arm is in place
+
+extruder_move_speed: 120                                   # Override the extruder speed during the filament loading/unloading
+extruder_move_accel: 800                                   # Override the extruder acceleration during the filament loading/unloading
 ```
 
 

--- a/README_zh_cn.md
+++ b/README_zh_cn.md
@@ -62,26 +62,29 @@ extra_servo_dwell_down: 0                                  #
 
 encoder_sample_time: 0.1                                   # ERCF样本时间
 encoder_poll_time: 0.0001                                  # 编码器轮询时间，单位为秒
-long_moves_speed: 100                                      # 长脉冲移动速度，单位为mm/s
-long_moves_accel: 400                                      # 长脉冲移动加速度，单位为mm/s^2。需要注意的是该设置只能配置ERCF挤出机的加速度
-short_moves_speed: 25                                      # 短脉冲移动速度，单位为mm/s
-short_moves_accel: 400                                     # 短脉冲移动加速度，单位为mm/s^2。需要注意的是该设置只能配置ERCF挤出机的加速度
-extruder_move_speed: 100                                   # 挤出机挤出速度，单位为mm/s
+long_moves_speed: 100                                      # 长脉冲移动速度，单位为 mm/s
+long_moves_accel: 400                                      # 长脉冲移动加速度，单位为 mm/s^2。需要注意的是该设置只能配置ERCF挤出机的加速度
+short_moves_speed: 25                                      # 短脉冲移动速度，单位为 mm/s
+short_moves_accel: 400                                     # 短脉冲移动加速度，单位为 mm/s^2。需要注意的是该设置只能配置ERCF挤出机的加速度
+extruder_move_speed: 100                                   # 挤出机挤出速度，单位为 mm/s
 extruder_move_accel: 400                                   # 挤出机挤出加速度，单位为 mm/s^2
 gear_stepper_long_move_threshold: 70                       # (已过时) 区分长短脉冲的临界值
 
 extra_move_margin: 100                                     # 等待触发时额外的耗材挤出距离。触发条件为耗材打滑或是耗材触发了工具头上的断料检测
-long_move_distance: 30                                     # 长脉冲移动距离，单位为mm
-short_move_distance: 10                                    # 短脉冲移动距离，单位为mm
-minimum_step_distance: 5                                   # ERCF编码器最低可检测耗材移动距离，单位为mm
-maximum_move_distance: 1500                                # 最大单次移动距离（可包含多个脉冲移动），单位为mm
-maximum_step_distance: 1500                                # 最大单步移动距离，单位为mm
-calibrate_move_distance_per_step: 3                        # 校准时耗材单步移动距离，单位为mm
+long_move_distance: 30                                     # 长脉冲移动距离，单位为 mm
+short_move_distance: 10                                    # 短脉冲移动距离，单位为 mm
+minimum_step_distance: 5                                   # ERCF编码器最低可检测耗材移动距离，单位为 mm
+maximum_move_distance: 1500                                # 最大单次移动距离（可包含多个脉冲移动），单位为 mm
+maximum_step_distance: 1500                                # 最大单步移动距离，单位为 mm
+calibrate_move_distance_per_step: 3                        # 校准时耗材单步移动距离，单位为 mm
 
 selector_filament_engagement_retry: 2                      # 最大尝试次数（用于ERCF挤出机无法咬住耗材时重试）
 auto_home_selector: True                                   # 若选择器未归零则任何选择器相关的移动将触发归零动作
 tip_forming_gcode_before_calibration: None                 # 长度校准之前运行的耗材头抽插宏
 slip_detection_ratio_threshold: 3                          # 耗材打滑比例 （若每步耗材实际移动距离小于[1/threshold * requested_distance]则认为是打滑）
+
+extruder_move_speed: 120                                   # 覆盖挤出机挤出速度，单位为 mm/s
+extruder_move_accel: 800                                   # 覆盖挤出机挤出加速度，单位为 mm/s^2
 ```
 
 # ERCF校准

--- a/ercf.py
+++ b/ercf.py
@@ -263,7 +263,7 @@ class ERCF(object):
             curtime = self.printer.get_reactor().monotonic()
             status = idle_timeout.get_status(curtime)
             if status['state'] == 'Printing':
-                gcmd.respond_info('Caught exception: {}, Calling {}'.format(e, self.MACRO_PAUSE))
+                self.log_to_gcmd_respond(gcmd, 'Caught exception: {}, Calling {}'.format(e, self.MACRO_PAUSE))
                 self.gcode.run_script_from_command(self.MACRO_PAUSE)
             else:
                 if self.debug_mode:
@@ -451,7 +451,7 @@ class ERCF(object):
         self.motion_counter.reset_counts()
 
         accumulated_move_distance = 0
-        gcmd.respond_info('Requested stepper move distance: {} with step length: {}, accel: {}'.format(
+        self.log_to_gcmd_respond(gcmd, 'Requested stepper move distance: {} with step length: {}, accel: {}'.format(
             target_move_distance, step_distance, step_accel))
 
         try:
@@ -500,14 +500,14 @@ class ERCF(object):
             if raise_on_filament_slip:
                 raise self.printer.command_error(msg)
             else:
-                gcmd.respond_info(msg)
+                self.log_to_gcmd_respond(gcmd, msg)
         except StopConditionException:
             pass
         finally:
             if stepper_stop_callback:
                 stepper_stop_callback(stepper_status)
 
-        gcmd.respond_info('Actual stepper move distance: {}'.format(accumulated_move_distance * direction))
+        self.log_to_gcmd_respond(gcmd, 'Actual stepper move distance: {}'.format(accumulated_move_distance * direction))
 
         return accumulated_move_distance * direction
 
@@ -583,8 +583,8 @@ class ERCF(object):
                                                             initial_condition_callback=stop_on_filament_not_present,
                                                             stop_condition_callback=stop_on_filament_not_present)
 
-        gcmd.respond_info('The filament tip is now parked right before the filament sensor. The total move distance: {}'
-                          .format(accumulated_move_distance))
+        self.log_to_gcmd_respond(
+            gcmd, 'The filament tip is now parked right before the filament sensor. The total move distance: {}'.format(accumulated_move_distance))
 
         return accumulated_move_distance
 
@@ -602,7 +602,6 @@ class ERCF(object):
                                                             stop_condition_callback=self._stop_on_filament_present,
                                                             expect_partial_move=True)
 
-
         # Extrude to the toolhead (without feedback)
         nozzle_to_sensor_length = self.all_variables.get('calibrated_nozzle_to_sensor_length')
         accumulated_move_distance += self.toolhead_move_wait(gcmd,
@@ -611,7 +610,7 @@ class ERCF(object):
                                                              step_speed=self.short_moves_speed,
                                                              raise_on_filament_slip=False)
 
-        gcmd.respond_info('The filament is loaded to the nozzle. The total move distance: {}'.format(accumulated_move_distance))
+        self.log_to_gcmd_respond(gcmd, 'The filament is loaded to the nozzle. The total move distance: {}'.format(accumulated_move_distance))
 
         return accumulated_move_distance
 
@@ -620,14 +619,14 @@ class ERCF(object):
         retract_distance = self.all_variables.get('calibrated_sensor_to_extruder_length') - self.long_move_distance
         accumulated_move_distance = self.toolhead_move_wait(gcmd, -retract_distance, raise_on_filament_slip=False,)
 
-        gcmd.respond_info(
+        self.log_to_gcmd_respond(gcmd,
             'The filament unloaded just passed the extruder. The total move distance: {}'.format(accumulated_move_distance))
 
         return accumulated_move_distance
 
     def ercf_unload_from_extruder_to_selector(self, gcmd):
         accumulated_move_distance = 0
-        gcmd.respond_info('Unloading from extruder to the selector')
+        self.log_to_gcmd_respond(gcmd, 'Unloading from extruder to the selector')
         with self._gear_stepper_move_guard():
             self.servo_down()
             # Move a little by both toolhead and gear stepper to help pulling from the extruder
@@ -686,21 +685,33 @@ class ERCF(object):
 
         # Unload from toolhead
         if self.toolhead_sensor is None:
-            # TODO:
             #   1. Run tip forming
             #   2. Unload a known distance (calibrated_nozzle_to_extruder_length)
             #   3. If filament is not moving, then unload to selector
-            raise NotImplementedError
+            self.gcode.run_script_from_command('_ERCF_FORM_TIP_STANDALONE')
+
+            # Unload with single move
+            self.log_to_gcmd_respond(gcmd, "Unloading from nozzle to extruder")
+            target_move_distance = self.all_variables.get('calibrated_nozzle_to_extruder_length') + self.extra_move_margin
+            accumulated_move_distance = self.toolhead_move_wait(gcmd, raise_on_filament_slip=False,
+                                                                target_move_distance=-target_move_distance,
+                                                                step_distance=target_move_distance,
+                                                                step_speed=self.long_moves_speed,
+                                                                expect_partial_move=True  # I'm expecting filament to slip as we moved with extra distance
+                                                                )
+
+            # Unload to selector
+            accumulated_move_distance += self.ercf_unload_from_extruder_to_selector(gcmd)
 
         elif self.toolhead_sensor.runout_helper.filament_present:
             # TODO: Make it a function instead of running as the macro
             self.gcode.run_script_from_command('_ERCF_FORM_TIP_STANDALONE')
 
-            gcmd.respond_info('Unloading from nozzle to toolhead sensor')
+            self.log_to_gcmd_respond(gcmd, 'Unloading from nozzle to toolhead sensor')
             self.ercf_unload_to_toolhead_sensor(gcmd)
 
             # This is the clean retraction
-            gcmd.respond_info('Unloading from toolhead sensor to extruder')
+            self.log_to_gcmd_respond(gcmd, 'Unloading from toolhead sensor to extruder')
             target_move_distance = self.all_variables['calibrated_sensor_to_extruder_length']
             actual_move_distance = self.toolhead_move_wait(gcmd,
                                                            target_move_distance=-target_move_distance,
@@ -723,7 +734,7 @@ class ERCF(object):
 
         # Unload from unknown location
         else:
-            gcmd.respond_info('Unloading from unknown location')
+            self.log_to_gcmd_respond(gcmd, 'Unloading from unknown location')
 
             # Do a short move to verify the filament is still engaged with the extruder
             actual_move_distance = self.toolhead_move_wait(gcmd,
@@ -785,22 +796,49 @@ class ERCF(object):
                     accumulated_move_distance += actual_move_distance
                     self.servo_up()
 
-        gcmd.respond_info('Filament is unloaded to the selector')
+        self.log_to_gcmd_respond(gcmd, 'Filament is unloaded to the selector with total move distance: {}'.format(accumulated_move_distance))
+
+    def ercf_load_from_extruder_to_nozzle(self, gcmd):
+        """
+        A single move from extruder to nozzle without feedback
+        """
+        nozzle_to_extruder_length = self.all_variables.get("calibrated_nozzle_to_extruder_length")
+        actual_move_distance = self.toolhead_move_wait(gcmd,
+                                                       target_move_distance=nozzle_to_extruder_length,
+                                                       step_distance=nozzle_to_extruder_length,
+                                                       step_speed=self.short_moves_speed,
+                                                       raise_on_filament_slip=False)
+        return actual_move_distance
 
     def ercf_load_from_unknown_location(self, gcmd):
+        accumulated_step_distance = 0
+
         if self.toolhead_sensor is None:
             # TODO:
             #   1. Check if the filament is engaged inside the extruder
             #       If true then move slowly with a certain distance (calibrated_nozzle_to_extruder_length) -> Finish
             #       If false then run the ercf_unload_from_extruder_to_selector
             #   2. Load fresh
-            raise NotImplementedError
-        if self.toolhead_sensor.runout_helper.filament_present:
+            try:
+                accumulated_step_distance += self.toolhead_move_wait(gcmd, raise_on_filament_slip=True,
+                                                                     target_move_distance=self.short_move_distance,
+                                                                     step_distance=self.short_move_distance,
+                                                                     step_speed=self.short_moves_speed,
+                                                                     expect_partial_move=False)
+            except self.printer.command_error:
+                # unload, the filament is between extruder and selector, or even before the selector
+                self.ercf_unload_from_extruder_to_selector(gcmd)
+                self.ercf_load_fresh(gcmd)
+            else:
+                # Load to the nozzle
+                accumulated_step_distance += self.ercf_load_from_extruder_to_nozzle(gcmd)
+
+        elif self.toolhead_sensor.runout_helper.filament_present:
             self.ercf_load_from_toolhead_sensor(gcmd)
         else:
             with self._gear_stepper_move_guard():
                 # Check if the filament is engaged inside the selector
-                gcmd.respond_info('Check filament engagement inside selector')
+                self.log_to_gcmd_respond(gcmd, 'Check filament engagement inside selector')
                 test_move_distance = 0
                 for i in range(self.selector_filament_engagement_retry):
                     self.servo_down()
@@ -817,7 +855,7 @@ class ERCF(object):
                         break
                     else:
                         self.servo_up()
-                    gcmd.respond_info('Filament is not engaged. Will retry')
+                    self.log_to_gcmd_respond(gcmd, 'Filament is not engaged. Will retry')
                 else:
                     raise self.printer.command_error('Filament is not engaged inside the selector. Please insert the filament manually')
 
@@ -863,13 +901,13 @@ class ERCF(object):
                     break
                 else:
                     self.servo_up()
-                gcmd.respond_info('Filament is not engaged. Will retry')
+                self.log_to_gcmd_respond(gcmd, 'Filament is not engaged. Will retry')
             else:
                 raise self.printer.command_error(
                     'Filament is not engaged inside the selector. Please insert the filament manually')
 
             # Do a single move to feed the filament to the extruder
-            gcmd.respond_info('Feeding from selector to just before the extruder -- long single move with just gear stepper')
+            self.log_to_gcmd_respond(gcmd, 'Feeding from selector to just before the extruder -- long single move with just gear stepper')
             accumulated_step_distance = test_move_distance
             target_distance = max(0, self.all_variables['calibrated_extruder_to_selector_length'] - test_move_distance - self.long_move_distance)
             actual_distance = self.gear_stepper_move_wait(gcmd,
@@ -880,7 +918,7 @@ class ERCF(object):
             accumulated_step_distance += actual_distance
 
             # Feed to the extruder
-            gcmd.respond_info('Feeding to the extruder -- short pulse move using both extruders and stop on filament slip')
+            self.log_to_gcmd_respond(gcmd, 'Feeding to the extruder -- short pulse move using both extruders and stop on filament slip')
             target_distance = max(0, self.all_variables['calibrated_extruder_to_selector_length'] - actual_distance) + self.long_move_distance
             actual_distance = self.stepper_move_wait(gcmd,
                                                      target_move_distance=target_distance,
@@ -898,7 +936,7 @@ class ERCF(object):
 
         if self.toolhead_sensor is not None:
             # Move the toolhead single long move approaching the sensor
-            gcmd.respond_info('Feeding from the extruder to just before the sensor -- long single move with just the extruder, stop on filament sensor trigger')
+            self.log_to_gcmd_respond(gcmd, 'Feeding from the extruder to just before the sensor -- long single move with just the extruder, stop on filament sensor trigger')
             target_distance = max(0, self.all_variables['calibrated_sensor_to_extruder_length'] - actual_distance - self.long_move_distance)
             if target_distance < self.long_move_distance:
                 step_distance = self.short_move_distance
@@ -913,7 +951,7 @@ class ERCF(object):
             accumulated_step_distance += actual_distance
 
             # Since we are closed to the toolhead sensor, we want do move slowly
-            gcmd.respond_info('Feeding to the sensor -- short pulse move and stop on filament sensor trigger')
+            self.log_to_gcmd_respond(gcmd, 'Feeding to the sensor -- short pulse move and stop on filament sensor trigger')
             target_distance = max(0, self.all_variables['calibrated_sensor_to_extruder_length'] - actual_distance) + self.long_move_distance
             accumulated_step_distance += self.toolhead_move_wait(gcmd,
                                                                  target_move_distance=target_distance,
@@ -926,8 +964,8 @@ class ERCF(object):
             # we are on the filament sensor, move the final distance
             self.ercf_load_from_toolhead_sensor(gcmd)
         else:
-            # TODO: move slowly with a certain distance (calibrated_nozzle_to_extruder_length) -> Finish
-            raise NotImplementedError
+            # Blind move from extruder to nozzle
+            self.ercf_load_from_extruder_to_nozzle(gcmd)
 
     def is_filament_in_selector(self, lift_servo=True, skip_filament_block_check=False):
         with self._gear_stepper_move_guard(lift_servo):
@@ -972,7 +1010,7 @@ class ERCF(object):
 
         # Check the filament status
         if self.is_filament_in_selector():
-            gcmd.respond_info('Filament is still in the selector cart. Will do the unload')
+            self.log_to_gcmd_respond(gcmd, 'Filament is still in the selector cart. Will do the unload')
 
             # There is chance this will fail as the filament already retracted in the block but require 1-3mm retraction
             try:
@@ -981,10 +1019,10 @@ class ERCF(object):
                 # Check if the filament is in the selector again. If clear then we should ignore the unload error
                 if self.is_filament_in_selector():
                     # Not good. Need some help from the user
-                    gcmd.respond_info('Unable to clear the filament from the selector. Requires user attention')
+                    self.log_to_gcmd_respond(gcmd, 'Unable to clear the filament from the selector. Requires user attention')
                     raise
                 else:
-                    gcmd.respond_info('Filament is clear from the selector. Will continue homing')
+                    self.log_to_gcmd_respond(gcmd, 'Filament is clear from the selector. Will continue homing')
 
         # TODO: Implement the sensorless homing
         self.selector_stepper.do_set_position(0)
@@ -1011,7 +1049,7 @@ class ERCF(object):
         self._current_tool = None
         self.ercf_move_selector_to_tool(gcmd, tool_idx=0, force=True)
 
-        gcmd.respond_info('Selector homed')
+        self.log_to_gcmd_respond(gcmd, 'Selector homed')
 
     def ercf_move_selector_to_tool(self, gcmd, tool_idx, force=False):
         color_selector_positions = self.all_variables['color_selector_positions']
@@ -1027,7 +1065,7 @@ class ERCF(object):
 
             # Check the filament status
             elif not force and self.is_filament_in_selector():
-                gcmd.respond_info('Filament is still in the selector cart. Will do the unload')
+                self.log_to_gcmd_respond(gcmd, 'Filament is still in the selector cart. Will do the unload')
                 self.ercf_unload(gcmd)
 
             # Move the selector
@@ -1037,10 +1075,10 @@ class ERCF(object):
                                           accel=self.short_moves_accel)
 
             self._current_tool = tool_idx
-            gcmd.respond_info('Tool {} is selected'.format(tool_idx))
+            self.log_to_gcmd_respond(gcmd, 'Tool {} is selected'.format(tool_idx))
 
         else:
-            gcmd.respond_info('Tool {} is already selected'.format(tool_idx))
+            self.log_to_gcmd_respond(gcmd, 'Tool {} is already selected'.format(tool_idx))
 
     def ercf_change_tool(self, gcmd, tool_idx):
         self.ercf_move_selector_to_tool(gcmd, tool_idx)
@@ -1049,7 +1087,7 @@ class ERCF(object):
         extrusion_factor = self.all_variables['calibrated_tool_extrusion_factor'][tool_idx]
         new_rotation_distance = self.reference_gear_stepper_rotation_distance / extrusion_factor
         self.gear_stepper.get_steppers()[0].set_rotation_distance(new_rotation_distance)
-        gcmd.respond_info('Tool {} update rotation distance from {} ref to {}'.format(tool_idx,
+        self.log_to_gcmd_respond(gcmd, 'Tool {} update rotation distance from {} ref to {}'.format(tool_idx,
                                                                                       self.reference_gear_stepper_rotation_distance,
                                                                                       new_rotation_distance))
 
@@ -1084,7 +1122,7 @@ class ERCF(object):
         final_position = self.selector_stepper.get_steppers()[0].get_mcu_position()
         travel_distance = abs(final_position - initial_position) * self.selector_stepper.get_steppers()[0].get_step_dist()
 
-        gcmd.respond_info('Tool {} location: {}'.format(tool_idx, travel_distance))
+        self.log_to_gcmd_respond(gcmd, 'Tool {} location: {}'.format(tool_idx, travel_distance))
 
         self.all_variables['color_selector_positions'][tool_idx] = travel_distance
 
@@ -1106,7 +1144,7 @@ class ERCF(object):
             self.servo_down()
             for speed, accel in product(speeds, accels):
                 for _ in range(repeats):
-                    gcmd.respond_info('Speed: {}, Acceleration: {}'.format(speed, accel))
+                    self.log_to_gcmd_respond(gcmd, 'Speed: {}, Acceleration: {}'.format(speed, accel))
                     # Moving forwards
                     self.motion_counter.reset_counts()
 
@@ -1115,7 +1153,7 @@ class ERCF(object):
                     self.toolhead.wait_moves()
 
                     count = self.motion_counter.get_counts()
-                    gcmd.respond_info('Forward Count: {}'.format(count))
+                    self.log_to_gcmd_respond(gcmd, 'Forward Count: {}'.format(count))
                     forward_count.append(count)
 
                     # Moving backwards
@@ -1123,7 +1161,7 @@ class ERCF(object):
                     self.gear_stepper.do_move(0, speed, accel, True)
                     self.toolhead.wait_moves()
                     count = self.motion_counter.get_counts()
-                    gcmd.respond_info('Backward Count: {}'.format(count))
+                    self.log_to_gcmd_respond(gcmd, 'Backward Count: {}'.format(count))
                     backward_count.append(count)
 
             self.servo_up()
@@ -1135,7 +1173,7 @@ class ERCF(object):
         # TODO: Why half median?
         resolution = calibrate_move_distance / half_mean
 
-        gcmd.respond_info('Old resolution: {}, New resolution: {}'.format(self.all_variables['calibrated_encoder_resolution'],
+        self.log_to_gcmd_respond(gcmd, 'Old resolution: {}, New resolution: {}'.format(self.all_variables['calibrated_encoder_resolution'],
                                                                           resolution))
         # Apply result
         self.motion_counter.set_encoder_steps(resolution)
@@ -1155,7 +1193,7 @@ class ERCF(object):
         repeats = gcmd.get_int('REPEATS', 1)
         calibrate_move_distance = min(self.all_variables['calibrated_extruder_to_selector_length'] * 0.66, 200)
 
-        gcmd.respond_info('Tool {} requesting to move {} for extrusion factor calibration'.format(tool_idx, calibrate_move_distance))
+        self.log_to_gcmd_respond(gcmd, 'Tool {} requesting to move {} for extrusion factor calibration'.format(tool_idx, calibrate_move_distance))
 
         self.ercf_move_selector_to_tool(gcmd, tool_idx)
 
@@ -1168,7 +1206,7 @@ class ERCF(object):
             self.servo_down()
             for speed, accel in product(speeds, accels):
                 for _ in range(repeats):
-                    gcmd.respond_info('Speed: {}, Acceleration: {}'.format(speed, accel))
+                    self.log_to_gcmd_respond(gcmd, 'Speed: {}, Acceleration: {}'.format(speed, accel))
                     # Moving forwards
                     self.motion_counter.reset_counts()
 
@@ -1177,7 +1215,7 @@ class ERCF(object):
                     self.toolhead.wait_moves()
 
                     distance = self.motion_counter.get_distance()
-                    gcmd.respond_info('Forward distance: {}'.format(distance))
+                    self.log_to_gcmd_respond(gcmd, 'Forward distance: {}'.format(distance))
                     forward_count.append(distance)
 
                     # Moving backwards
@@ -1185,7 +1223,7 @@ class ERCF(object):
                     self.gear_stepper.do_move(0, speed, accel, True)
                     self.toolhead.wait_moves()
                     distance = self.motion_counter.get_distance()
-                    gcmd.respond_info('Backward distance: {}'.format(distance))
+                    self.log_to_gcmd_respond(gcmd, 'Backward distance: {}'.format(distance))
                     backward_count.append(distance)
 
             self.servo_up()
@@ -1194,11 +1232,11 @@ class ERCF(object):
         backward_median = median(backward_count)
         mean = (forward_median + backward_median) / 2.0
 
-        gcmd.respond_info('Tool {} moved {}'.format(tool_idx, mean))
+        self.log_to_gcmd_respond(gcmd, 'Tool {} moved {}'.format(tool_idx, mean))
 
         extrusion_factor = calibrate_move_distance / mean
 
-        gcmd.respond_info('Tool {} extrusion factor: {}'.format(tool_idx, extrusion_factor))
+        self.log_to_gcmd_respond(gcmd, 'Tool {} extrusion factor: {}'.format(tool_idx, extrusion_factor))
 
         # Apply
         self.all_variables['calibrated_tool_extrusion_factor'][tool_idx] = extrusion_factor

--- a/ercf.py
+++ b/ercf.py
@@ -241,7 +241,7 @@ class ERCF(object):
         self._current_tool = None
 
     def log_to_gcmd_respond(self, gcmd, text):
-        gcmd.respond_info("AdaptiveBedMesh:" + text)
+        gcmd.respond_info("ERCF:" + text)
 
     @contextmanager
     def _gear_stepper_move_guard(self, lift_servo=True):
@@ -1274,8 +1274,8 @@ class ERCF(object):
             try:
                 actual_distance = self.toolhead_move_wait(gcmd, raise_on_filament_slip=False,
                                                           target_move_distance=self.all_variables.get('calibrated_nozzle_to_extruder_length') + self.extra_move_margin,
-                                                          step_distance=self.calibrate_move_distance_per_step,
-                                                          step_speed=self.short_moves_speed,
+                                                          step_distance=self.long_move_distance,  # Use single long move to get filament out
+                                                          step_speed=self.long_moves_speed,
                                                           expect_partial_move=True)
             except self.printer.command_error:
                 raise FatalPrinterError(

--- a/ercf.py
+++ b/ercf.py
@@ -260,7 +260,8 @@ class ERCF(object):
             if idle_timeout is None:
                 raise self.printer.config_error("No idle timeout found")
 
-            status = idle_timeout.get_status()
+            curtime = self.printer.get_reactor().monotonic()
+            status = idle_timeout.get_status(curtime)
             if status['state'] == 'Printing':
                 gcmd.respond_info('Caught exception: {}, Calling {}'.format(e, self.MACRO_PAUSE))
                 self.gcode.run_script_from_command(self.MACRO_PAUSE)

--- a/ercf.py
+++ b/ercf.py
@@ -307,22 +307,22 @@ class ERCF(object):
 
     def cmd_ERCF_MOVE_SELECTOR_TO_TOOL(self, gcmd):
         with self._command_exception_handler(gcmd):
-            tool_idx = gcmd.get_int('TOOL')
+            tool_idx = int(gcmd.get("TOOL"))
             self.ercf_move_selector_to_tool(gcmd, tool_idx)
 
     def cmd_ERCF_CHANGE_TOOL(self, gcmd):
         with self._command_exception_handler(gcmd):
-            tool_idx = gcmd.get_int('TOOL')
+            tool_idx = int(gcmd.get("TOOL"))
             self.ercf_change_tool(gcmd, tool_idx)
 
     def cmd_ERCF_CALIBRATE_SELECTOR_LOCATION(self, gcmd):
         with self._command_exception_handler(gcmd):
-            tool_idx = gcmd.get_int('TOOL')
+            tool_idx = int(gcmd.get("TOOL"))
             self.calibrate_selector_location(gcmd, tool_idx)
 
     def cmd_ERCF_CALIBRATE_EXTRUSION_FACTOR(self, gcmd):
         with self._command_exception_handler(gcmd):
-            tool_idx = gcmd.get_int('TOOL')
+            tool_idx = int(gcmd.get("TOOL"))
             self.calibrate_extrusion_factor(gcmd, tool_idx)
 
     def cmd_CALIBRATE_GEAR_STEPPER_ROTATION_DISTANCE(self, gcmd):

--- a/ercf.py
+++ b/ercf.py
@@ -307,22 +307,22 @@ class ERCF(object):
 
     def cmd_ERCF_MOVE_SELECTOR_TO_TOOL(self, gcmd):
         with self._command_exception_handler(gcmd):
-            tool_idx = int(gcmd.get("TOOL"))
+            tool_idx = int(gcmd.get_float("TOOL"))
             self.ercf_move_selector_to_tool(gcmd, tool_idx)
 
     def cmd_ERCF_CHANGE_TOOL(self, gcmd):
         with self._command_exception_handler(gcmd):
-            tool_idx = int(gcmd.get("TOOL"))
+            tool_idx = int(gcmd.get_float("TOOL"))
             self.ercf_change_tool(gcmd, tool_idx)
 
     def cmd_ERCF_CALIBRATE_SELECTOR_LOCATION(self, gcmd):
         with self._command_exception_handler(gcmd):
-            tool_idx = int(gcmd.get("TOOL"))
+            tool_idx = int(gcmd.get_float("TOOL"))
             self.calibrate_selector_location(gcmd, tool_idx)
 
     def cmd_ERCF_CALIBRATE_EXTRUSION_FACTOR(self, gcmd):
         with self._command_exception_handler(gcmd):
-            tool_idx = int(gcmd.get("TOOL"))
+            tool_idx = int(gcmd.get_float("TOOL"))
             self.calibrate_extrusion_factor(gcmd, tool_idx)
 
     def cmd_CALIBRATE_GEAR_STEPPER_ROTATION_DISTANCE(self, gcmd):

--- a/ercf.py
+++ b/ercf.py
@@ -830,7 +830,7 @@ class ERCF(object):
                 self.ercf_load_fresh(gcmd)
             else:
                 # Load to the nozzle
-                accumulated_step_distance += self.ercf_load_from_extruder_to_nozzle(gcmd, accumulated_step_distance)
+                accumulated_step_distance += self.ercf_load_from_extruder_to_nozzle(gcmd, self.short_move_distance)
 
         elif self.toolhead_sensor.runout_helper.filament_present:
             self.ercf_load_from_toolhead_sensor(gcmd)
@@ -964,7 +964,7 @@ class ERCF(object):
             self.ercf_load_from_toolhead_sensor(gcmd)
         else:
             # Blind move from extruder to nozzle
-            self.ercf_load_from_extruder_to_nozzle(gcmd, actual_distance)
+            self.ercf_load_from_extruder_to_nozzle(gcmd, self.short_move_distance)
 
     def is_filament_in_selector(self, lift_servo=True, skip_filament_block_check=False):
         with self._gear_stepper_move_guard(lift_servo):

--- a/ercf.py
+++ b/ercf.py
@@ -1275,7 +1275,7 @@ class ERCF(object):
                 actual_distance = self.toolhead_move_wait(gcmd, raise_on_filament_slip=False,
                                                           target_move_distance=self.all_variables.get('calibrated_nozzle_to_extruder_length') + self.extra_move_margin,
                                                           step_distance=self.long_move_distance,  # Use single long move to get filament out
-                                                          step_speed=self.long_moves_speed,
+                                                          step_speed=self.short_moves_speed,
                                                           expect_partial_move=True)
             except self.printer.command_error:
                 raise FatalPrinterError(

--- a/ercf.py
+++ b/ercf.py
@@ -1284,7 +1284,7 @@ class ERCF(object):
                     'https://github.com/eamars/ercf_driver/blob/main/ercf_vars.cfg'
                 )
 
-            self.all_variables['calibrated_nozzle_to_extruder_length'] = actual_distance
+            self.all_variables['calibrated_nozzle_to_extruder_length'] = abs(actual_distance)
 
             self.log_to_gcmd_respond(gcmd, "Stage 1 Done")
 
@@ -1307,7 +1307,7 @@ class ERCF(object):
                     'the filament can be ejected to the spool'
                 )
 
-            self.all_variables['calibrated_nozzle_to_sensor_length'] = actual_distance
+            self.all_variables['calibrated_nozzle_to_sensor_length'] = abs(actual_distance)
 
             self.log_to_gcmd_respond(gcmd, "Stage 1a Done")
 
@@ -1331,7 +1331,7 @@ class ERCF(object):
                     'https://github.com/eamars/ercf_driver/blob/main/ercf_vars.cfg'
                 )
 
-            self.all_variables['calibrated_nozzle_to_extruder_length'] = actual_distance
+            self.all_variables['calibrated_nozzle_to_extruder_length'] = abs(actual_distance)
 
             self.log_to_gcmd_respond(gcmd, "Stage 1b Done")
 
@@ -1380,6 +1380,7 @@ class ERCF(object):
                     'https://github.com/eamars/ercf_driver/blob/main/ercf_vars.cfg'
                 )
 
+            self.all_variables['calibrated_extruder_to_selector_length'] = abs(actual_distance)
             self.log_to_gcmd_respond(gcmd, "Stage 2b Done")
 
         ############

--- a/ercf.py
+++ b/ercf.py
@@ -1273,7 +1273,7 @@ class ERCF(object):
             self.log_to_gcmd_respond(gcmd, "Stage 1: Calibrating nozzle to extruder length")
             try:
                 actual_distance = self.toolhead_move_wait(gcmd, raise_on_filament_slip=False,
-                                                          target_move_distance=self.all_variables.get('calibrated_nozzle_to_extruder_length') + self.extra_move_margin,
+                                                          target_move_distance=-(self.all_variables.get('calibrated_nozzle_to_extruder_length') + self.extra_move_margin),
                                                           step_distance=self.long_move_distance,  # Use single long move to get filament out
                                                           step_speed=self.short_moves_speed,
                                                           expect_partial_move=True)
@@ -1298,7 +1298,7 @@ class ERCF(object):
             self.log_to_gcmd_respond(gcmd, "Stage 1a: Calibrating nozzle to sensor length")
             try:
                 actual_distance = self.toolhead_move_wait(gcmd, raise_on_filament_slip=True,
-                                                          target_move_distance=self.all_variables.get('calibrated_nozzle_to_sensor_length'),
+                                                          target_move_distance=-(self.all_variables.get('calibrated_nozzle_to_sensor_length') + self.extra_move_margin),
                                                           step_distance=self.calibrate_move_distance_per_step,
                                                           step_speed=self.short_moves_speed)
             except self.printer.command_error:
@@ -1320,8 +1320,7 @@ class ERCF(object):
             self.log_to_gcmd_respond(gcmd, "Stage 1b: Calibrating sensor to extruder length")
             try:
                 actual_distance = self.toolhead_move_wait(gcmd, raise_on_filament_slip=False,
-                                                          target_move_distance=self.all_variables.get(
-                                                              'calibrated_nozzle_to_extruder_length') + self.extra_move_margin,
+                                                          target_move_distance=-(self.all_variables.get('calibrated_nozzle_to_extruder_length') + self.extra_move_margin),
                                                           step_distance=self.calibrate_move_distance_per_step,
                                                           step_speed=self.short_moves_speed,
                                                           expect_partial_move=True)
@@ -1349,7 +1348,7 @@ class ERCF(object):
             self.log_to_gcmd_respond(gcmd, "Stage 2a: Calibrating extruder to selector length (small sync move)")
             try:
                 actual_distance = self.stepper_move_wait(gcmd,
-                                                         target_move_distance=self.short_move_distance,
+                                                         target_move_distance=-self.short_move_distance,
                                                          stepper_block_move_callback=self._toolhead_gear_stepper_synchronized_block_move,
                                                          stepper_init_callback=self._toolhead_move_init,
                                                          stepper_stop_callback=self._toolhead_move_stop,
@@ -1368,7 +1367,7 @@ class ERCF(object):
             self.log_to_gcmd_respond(gcmd, "Stage 2b: Calibrating extruder to selector length")
             try:
                 actual_distance += self.gear_stepper_move_wait(gcmd,
-                                                               target_move_distance=self.all_variables['calibrated_extruder_to_selector_length'] + self.extra_move_margin,
+                                                               target_move_distance=-(self.all_variables['calibrated_extruder_to_selector_length'] + self.extra_move_margin),
                                                                step_distance=self.calibrate_move_distance_per_step,
                                                                step_speed=self.short_moves_speed,
                                                                step_accel=self.short_moves_accel,

--- a/ercf_config.cfg
+++ b/ercf_config.cfg
@@ -26,7 +26,7 @@ stealthchop_threshold: 1  # Set to stealthchop while the gear stepper is idling
 # Feeder selector
 [manual_stepper selector_stepper]
 step_pin: ercf:gpio7
-dir_pin: ercf:gpio8
+dir_pin: !ercf:gpio8
 enable_pin: !ercf:gpio6
 microsteps: 32
 rotation_distance: 40
@@ -61,7 +61,7 @@ extruder: extruder
 gear_stepper: manual_stepper gear_stepper                  # full name is required
 selector_stepper: manual_stepper selector_stepper          # full name is required
 servo: servo ercf_servo                                    # full name is required
-toolhead_sensor: filament_switch_sensor toolhead_sensor    # full name is required
+# toolhead_sensor: filament_switch_sensor toolhead_sensor    # full name is required
 encoder_pin: ercf:gpio15                                   # The pin must be shared via [duplicate_pin_override]
 
 servo_up_angle: 30                                         # The angle when the servo arm is in UP position. See the ERCF manual for more information.
@@ -77,8 +77,8 @@ encoder_sample_time: 0.1                                   # The ERCF encoder sa
 encoder_poll_time: 0.0001                                  # The ERCF encoder poll time in seconds.
 long_moves_speed: 100                                      # Long pulse move speed in mm/s. The speed is also been used by the single long move.
 long_moves_accel: 400                                      # Long pulse move acceleration in mm/s^2. Note the acceleration only apply to gear stepper motion.
-short_moves_speed: 25                                      # Short pulse move speed in mm/s.
-short_moves_accel: 400                                     # Short pulse move acceleration in mm/s^2. Note the acceleration only apply to gear stepper motion.
+short_moves_speed: 50                                      # Short pulse move speed in mm/s.
+short_moves_accel: 800                                     # Short pulse move acceleration in mm/s^2. Note the acceleration only apply to gear stepper motion.
 extruder_move_speed: 100                                   # Extruder move speed override, in mm/s
 extruder_move_accel: 400                                   # Extruder move acceleration override, in mm/s^2
 gear_stepper_long_move_threshold: 70                       # (Deprecated) The threshold that determines the move speed/acceleration between short and long move.
@@ -96,3 +96,6 @@ auto_home_selector: True                                   # Automatically home 
 tip_forming_gcode_before_calibration: None                 # The tip forming gcode to run before running the calibration routine (_ERCF_CALIBRATE_COMPONENT_LENGTH).
 slip_detection_ratio_threshold: 3                          # If the actual move distance is less than [1/threshold * requested_distance] then the code will consider it slip
 servo_down_turn_off: False                                 # Select whether to turn off the servo motor while the arm is in place
+
+extruder_move_speed: 120                                   # Override the extruder speed during the filament loading/unloading
+extruder_move_accel: 800                                   # Override the extruder acceleration during the filament loading/unloading

--- a/ercf_config.cfg
+++ b/ercf_config.cfg
@@ -93,7 +93,7 @@ calibrate_move_distance_per_step: 3                        # The step distance i
 
 selector_filament_engagement_retry: 2                      # The maximum retry while the filament failes to engage.
 auto_home_selector: True                                   # Automatically home the selector if not homed previously when a selector move is requested.
-tip_forming_gcode_before_calibration: None                 # The tip forming gcode to run before running the calibration routine (_ERCF_CALIBRATE_COMPONENT_LENGTH).
+tip_forming_gcode_before_calibration: _ERCF_FORM_TIP_STANDALONE  # The tip forming gcode to run before running the calibration routine (_ERCF_CALIBRATE_COMPONENT_LENGTH).
 slip_detection_ratio_threshold: 3                          # If the actual move distance is less than [1/threshold * requested_distance] then the code will consider it slip
 servo_down_turn_off: False                                 # Select whether to turn off the servo motor while the arm is in place
 

--- a/ercf_config.cfg
+++ b/ercf_config.cfg
@@ -95,3 +95,4 @@ selector_filament_engagement_retry: 2                      # The maximum retry w
 auto_home_selector: True                                   # Automatically home the selector if not homed previously when a selector move is requested.
 tip_forming_gcode_before_calibration: None                 # The tip forming gcode to run before running the calibration routine (_ERCF_CALIBRATE_COMPONENT_LENGTH).
 slip_detection_ratio_threshold: 3                          # If the actual move distance is less than [1/threshold * requested_distance] then the code will consider it slip
+servo_down_turn_off: False                                 # Select whether to turn off the servo motor while the arm is in place

--- a/ercf_vars.cfg
+++ b/ercf_vars.cfg
@@ -1,9 +1,9 @@
 [Variables]
 calibrated_encoder_resolution = 1.39
-calibrated_extruder_to_selector_length = 1000
-calibrated_nozzle_to_extruder_length = 1000
-calibrated_nozzle_to_sensor_length = 1000
-calibrated_sensor_to_extruder_length = 1000
+calibrated_extruder_to_selector_length = 3000
+calibrated_nozzle_to_extruder_length = 3000
+calibrated_nozzle_to_sensor_length = 3000
+calibrated_sensor_to_extruder_length = 3000
 calibrated_tool_extrusion_factor = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
 color_selector_positions = [1.7, 23.2, 44, 70.4, 91.2, 112, 138.38125, 159.2, 180.8]
 

--- a/ercf_vars.cfg
+++ b/ercf_vars.cfg
@@ -1,9 +1,9 @@
 [Variables]
-calibrated_encoder_resolution = 1.349527665317139
-calibrated_extruder_to_selector_length = 407.5042629999994
-calibrated_nozzle_to_extruder_length = None
-calibrated_nozzle_to_sensor_length = 55.66
-calibrated_sensor_to_extruder_length = 567.6197659999998
+calibrated_encoder_resolution = 1.39
+calibrated_extruder_to_selector_length = 1000
+calibrated_nozzle_to_extruder_length = 1000
+calibrated_nozzle_to_sensor_length = 1000
+calibrated_sensor_to_extruder_length = 1000
 calibrated_tool_extrusion_factor = [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
 color_selector_positions = [1.7, 23.2, 44, 70.4, 91.2, 112, 138.38125, 159.2, 180.8]
 


### PR DESCRIPTION
Major changes are: 
* Refactored the calibration code
* Remove the support for filament sensor between the extruder and selector. 
* Add support to sensorless toolhead (for Voron 0) specifically. If you are running Voron 2.4 or Trident, still the toolhead with filament sensor is recommended. 